### PR TITLE
Updated Release Version to 1.20.30-r2 (#1399)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'cn.powernukkitx', name: 'powernukkitx', version: '1.20.30-r1'
+    compile group: 'cn.powernukkitx', name: 'powernukkitx', version: '1.20.30-r2'
 }
 ```
 
@@ -156,7 +156,7 @@ dependencies {
     <dependency>
         <groupId>cn.powernukkitx</groupId>
         <artifactId>powernukkitx</artifactId>
-        <version>1.20.30-r1</version>
+        <version>1.20.30-r2</version>
     </dependency>
 </dependencies>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>cn.powernukkitx</groupId>
     <artifactId>powernukkitx</artifactId>
-    <version>1.20.30-r1</version>
+    <version>1.20.30-r2</version>
 
     <inceptionYear>2023</inceptionYear>
     <organization>


### PR DESCRIPTION
* Made BlockWood use the same WoodType Block state as the other blocks (OLD_LOG_TYPE was deprecated)

* Fixed BlockRedstoneRepeater Direction

* Fixed block_mappings for log axis

* Removed doubled log2 section

* Updated Release Version to 1.20.30-r2

* release +u